### PR TITLE
chore(docs): improve ES6 code documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 bower_components
 compiled
-build
+dist
 sauce_connect.log
 .idea
 .DS_STORE

--- a/docs/dgeni.conf.js
+++ b/docs/dgeni.conf.js
@@ -7,7 +7,8 @@ var Package = require('dgeni').Package;
 // the jsdoc and nunjucks packages defined in the dgeni-packages npm module.
 var package = new Package('router', [
   require('dgeni-packages/jsdoc'),
-  require('dgeni-packages/nunjucks')
+  require('dgeni-packages/nunjucks'),
+  require('./traceur-package')
 ]);
 
 package.processor(require('./processors/markdown.js'));
@@ -29,7 +30,8 @@ package.config(function(log, readFilesProcessor, templateFinder, templateEngine,
   // Specify collections of source files that should contain the documentation to extract
   readFilesProcessor.sourceFiles = [
     { include: 'src/**/*.js', basePath: 'src' },
-    { include: 'docs/content/**/*.md', basePath: 'docs/content' }
+    { include: 'docs/content/**/*.md', basePath: 'docs/content' },
+    { include: 'src/**/*.ats', basePath: 'src' }
   ];
 
 

--- a/docs/processors/generateIndexPage.js
+++ b/docs/processors/generateIndexPage.js
@@ -9,14 +9,17 @@ var path = require('canonical-path');
  */
 module.exports = function generateIndexPageProcessor() {
   return {
+    includeDocFn: function(doc) { return ['js', 'markdown', 'module'].indexOf(doc.docType) >= 0; },
     $runAfter: ['adding-extra-docs'],
     $runBefore: ['extra-docs-added'],
     $process: function(docs) {
 
+      var includeDocFn = this.includeDocFn;
+
       // Collect up all the areas in the docs
       var docTypes = {};
       docs.forEach(function(doc) {
-        if ( doc.docType ) {
+        if (includeDocFn(doc)) {
           docTypes[doc.docType] = docTypes[doc.docType] || [];
           docTypes[doc.docType].push(doc);
         }

--- a/docs/rendering/docTypeLabel.js
+++ b/docs/rendering/docTypeLabel.js
@@ -2,7 +2,8 @@ var path = require('canonical-path');
 
 var LABELS = {
   markdown: 'Guide',
-  js: 'API'
+  js: 'API',
+  module: 'ES6 Modules'
 };
 
 module.exports = {

--- a/docs/templates/index.template.html
+++ b/docs/templates/index.template.html
@@ -1,4 +1,4 @@
-{% extends "common.template.html" %}
+{% extends "layout/base.template.html" %}
 
 {% block body %}
 

--- a/docs/templates/js.template.html
+++ b/docs/templates/js.template.html
@@ -1,4 +1,4 @@
-{% extends "common.template.html" %}
+{% extends "layout/base.template.html" %}
 
 {% block body %}
 

--- a/docs/templates/layout/base.template.html
+++ b/docs/templates/layout/base.template.html
@@ -3,8 +3,8 @@
   <meta charset="utf-8">
   <title>{% block title %}New Angular Router{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="style.css" rel="stylesheet">
-  <link href="highlight.css" rel="stylesheet">
+  <link href="/style.css" rel="stylesheet">
+  <link href="/highlight.css" rel="stylesheet">
 </head>
 <body lang="en">
   {% block body %}{% endblock %}

--- a/docs/templates/markdown.template.html
+++ b/docs/templates/markdown.template.html
@@ -1,4 +1,4 @@
-{% extends "common.template.html" %}
+{% extends "layout/base.template.html" %}
 
 {% block body %}
 {$ doc.renderedContent $}

--- a/docs/traceur-package/index.js
+++ b/docs/traceur-package/index.js
@@ -1,0 +1,99 @@
+var Package = require('dgeni').Package;
+var traceur = require('./services/traceur');
+var path = require('canonical-path');
+
+module.exports = new Package('traceur')
+
+.factory(require('./readers/atScript'))
+.factory(require('./services/getJSDocComment'))
+
+// Create injectable services from traceur classes and objects
+.factory(traceur.traceurOptions)
+.factory('SourceFile', traceur.getClass('SourceFile'))
+.factory('ParseTreeVisitor', traceur.getClass('ParseTreeVisitor'))
+.factory('Parser', traceur.getClass('Parser'))
+
+// This is the main wrapper around traceur that parses the content of ats files
+.factory(require('./services/atParser'))
+
+// Create tree visitor services that are used to extract info from the ASTs
+.factory(require('./services/AttachCommentTreeVisitor'))
+.factory(require('./services/ExportTreeVisitor'))
+
+
+// Processors
+.processor(require('./processors/generateDocsFromComments'))
+.processor(require('./processors/processModuleDocs'))
+.processor(require('./processors/processClassDocs'))
+
+
+// Configure file reader
+.config(function(readFilesProcessor, atScriptFileReader) {
+  readFilesProcessor.fileReaders.push(atScriptFileReader);
+})
+
+
+// Configure templates
+.config(function(templateFinder) {
+  templateFinder.templateFolders.push(path.resolve(__dirname, 'templates'));
+})
+
+// Configure ids and paths
+.config(function(computeIdsProcessor, computePathsProcessor) {
+
+  computeIdsProcessor.idTemplates.push({
+    docTypes: [
+      'class',
+      'function',
+      'NAMED_EXPORT',
+      'VARIABLE_STATEMENT'
+    ],
+    idTemplate: '${moduleDoc.id}.${name}',
+    getAliases: function(doc) { return [doc.id]; }
+  });
+
+  computeIdsProcessor.idTemplates.push({
+    docTypes: ['member'],
+    idTemplate: '${classDoc.id}.${name}',
+    getAliases: function(doc) { return [doc.id]; }
+  });
+
+  computeIdsProcessor.idTemplates.push({
+    docTypes: ['guide'],
+    getId: function(doc) {
+      return doc.fileInfo.relativePath
+                    // path should be relative to `modules` folder
+                    .replace(/.*\/?modules\//, '')
+                    // path should not include `/docs/`
+                    .replace(/\/docs\//, '/')
+                    // path should not have a suffix
+                    .replace(/\.\w*$/, '');
+    },
+    getAliases: function(doc) { return [doc.id]; }
+  });
+
+
+  computePathsProcessor.pathTemplates.push({
+    docTypes: ['module'],
+    pathTemplate: '${id}',
+    outputPathTemplate: '${id}/index.html'
+  });
+
+  computePathsProcessor.pathTemplates.push({
+    docTypes: [
+      'class',
+      'function',
+      'NAMED_EXPORT',
+      'VARIABLE_STATEMENT'
+    ],
+    pathTemplate: '${moduleDoc.path}/${name}',
+    outputPathTemplate: '${path}/index.html'
+  });
+
+  computePathsProcessor.pathTemplates.push({
+    docTypes: ['member'],
+    pathTemplate: '${classDoc.path}/${name}',
+    getOutputPath: function() {} // These docs are not written to their own file, instead they are part of their class doc
+  });
+});
+

--- a/docs/traceur-package/processors/generateDocsFromComments.js
+++ b/docs/traceur-package/processors/generateDocsFromComments.js
@@ -1,0 +1,34 @@
+var _ = require('lodash');
+
+module.exports = function generateDocsFromComments(log) {
+  return {
+    $runAfter: ['files-read'],
+    $runBefore: ['parsing-tags'],
+    $process: function(docs) {
+      var commentDocs = [];
+      docs = _.filter(docs, function(doc) {
+        if (doc.docType !== 'atScriptFile') {
+          return true;
+        } else {
+          _.forEach(doc.fileInfo.comments, function(comment) {
+
+            // we need to check for `/**` at the start of the comment to find all the jsdoc style comments
+            comment.range.toString().replace(/^\/\*\*([\w\W]*)\*\/$/g, function(match, commentBody) {
+
+              // Create a doc from this comment
+              commentDocs.push({
+                fileInfo: doc.fileInfo,
+                startingLine: comment.range.start.line,
+                endingLine: comment.range.end.line,
+                content: commentBody,
+                codeTree: comment.treeAfter,
+                docType: 'atScriptDoc'
+              });
+            });
+          });
+        }
+      });
+      return docs.concat(commentDocs);
+    }
+  };
+};

--- a/docs/traceur-package/processors/processClassDocs.js
+++ b/docs/traceur-package/processors/processClassDocs.js
@@ -1,0 +1,42 @@
+var _ = require('lodash');
+
+module.exports = function processClassDocs(log, getJSDocComment) {
+
+  return {
+    $runAfter: ['processModuleDocs'],
+    $runBefore: ['parsing-tags', 'generateDocsFromComments'],
+    $process: function(docs) {
+      var memberDocs = [];
+      _.forEach(docs, function(classDoc) {
+        if ( classDoc.docType === 'class' ) {
+
+          classDoc.members = [];
+
+          // Create a new doc for each member of the class
+          _.forEach(classDoc.elements, function(memberDoc) {
+
+            classDoc.members.push(memberDoc);
+            memberDocs.push(memberDoc);
+
+            memberDoc.docType = 'member';
+            memberDoc.classDoc = classDoc;
+            memberDoc.name = memberDoc.name.literalToken.value;
+
+            if (memberDoc.commentBefore ) {
+              // If this export has a comment, remove it from the list of
+              // comments collected in the module
+              var index = classDoc.moduleDoc.comments.indexOf(memberDoc.commentBefore);
+              if ( index !== -1 ) {
+                classDoc.moduleDoc.comments.splice(index, 1);
+              }
+
+              _.assign(memberDoc, getJSDocComment(memberDoc.commentBefore));
+            }
+          });
+        }
+      });
+
+      return docs.concat(memberDocs);
+    }
+  };
+};

--- a/docs/traceur-package/processors/processModuleDocs.js
+++ b/docs/traceur-package/processors/processModuleDocs.js
@@ -1,0 +1,48 @@
+var _ = require('lodash');
+
+module.exports = function processModuleDocs(log, ExportTreeVisitor, getJSDocComment) {
+
+  return {
+    $runAfter: ['files-read'],
+    $runBefore: ['parsing-tags', 'generateDocsFromComments'],
+    $process: function(docs) {
+      var exportDocs = [];
+      _.forEach(docs, function(doc) {
+        if (doc.docType === 'module') {
+
+          log.debug('processing', doc.moduleTree.moduleName);
+
+          doc.name = doc.moduleTree.moduleName;
+
+          doc.exports = [];
+
+          if (doc.moduleTree.visit) {
+            var visitor = new ExportTreeVisitor();
+            visitor.visit(doc.moduleTree);
+
+            _.forEach(visitor.exports, function(exportDoc) {
+
+              doc.exports.push(exportDoc);
+              exportDocs.push(exportDoc);
+              exportDoc.moduleDoc = doc;
+
+              if (exportDoc.comment) {
+                // If this export has a comment, remove it from the list of
+                // comments collected in the module
+                var index = doc.comments.indexOf(exportDoc.comment);
+                if ( index !== -1 ) {
+                  doc.comments.splice(index, 1);
+                }
+
+                _.assign(exportDoc, getJSDocComment(exportDoc.comment));
+              }
+
+            });
+          }
+        }
+      });
+
+      return docs.concat(exportDocs);
+    }
+  };
+};

--- a/docs/traceur-package/readers/atScript.js
+++ b/docs/traceur-package/readers/atScript.js
@@ -1,0 +1,30 @@
+var path = require('canonical-path');
+
+
+/**
+ * @dgService atScriptFileReader
+ * @description
+ * This file reader will create a simple doc for each
+ * file including a code AST of the AtScript in the file.
+ */
+module.exports = function atScriptFileReader(log, atParser) {
+  var reader = {
+    name: 'atScriptFileReader',
+    defaultPattern: /\.ats$/,
+    getDocs: function(fileInfo) {
+
+      var moduleDoc = atParser.parseModule(fileInfo);
+      moduleDoc.docType = 'module';
+      moduleDoc.id = moduleDoc.moduleTree.moduleName;
+      moduleDoc.aliases = [moduleDoc.id];
+
+      // Readers return a collection of docs read from the file
+      // but in this read there is only one document (module) to return
+      return [moduleDoc];
+    }
+  };
+
+  return reader;
+
+
+};

--- a/docs/traceur-package/readers/atScript.spec.js
+++ b/docs/traceur-package/readers/atScript.spec.js
@@ -1,0 +1,55 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+
+describe('atScript file reader', function() {
+
+  var dgeni, injector, reader;
+
+  var fileContent =
+    'import {CONST} from "facade/lang";\n' +
+    '\n' +
+    '/**\n' +
+     '* A parameter annotation that creates a synchronous eager dependency.\n' +
+     '*\n' +
+     '*    class AComponent {\n' +
+     '*      constructor(@Inject("aServiceToken") aService) {}\n' +
+     '*    }\n' +
+     '*\n' +
+     '*/\n' +
+    'export class Inject {\n' +
+      'token;\n' +
+      '@CONST()\n' +
+      'constructor(token) {\n' +
+        'this.token = token;\n' +
+      '}\n' +
+    '}';
+
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    reader = injector.get('atScriptFileReader');
+  });
+
+
+  it('should provide a default pattern', function() {
+    expect(reader.defaultPattern).toEqual(/\.ats$/);
+  });
+
+
+  it('should parse the file using the atParser and return a single doc', function() {
+
+    var atParser = injector.get('atParser');
+    spyOn(atParser, 'parseModule').and.callThrough();
+
+    var docs = reader.getDocs({
+      content: fileContent,
+      relativePath: 'di/src/annotations.js'
+    });
+
+    expect(atParser.parseModule).toHaveBeenCalled();
+    expect(docs.length).toEqual(1);
+    expect(docs[0].docType).toEqual('module');
+  });
+
+});

--- a/docs/traceur-package/services/AttachCommentTreeVisitor.js
+++ b/docs/traceur-package/services/AttachCommentTreeVisitor.js
@@ -1,0 +1,42 @@
+module.exports = function AttachCommentTreeVisitor(ParseTreeVisitor, log) {
+
+
+  // This visitor tries to find the nearest comment for each code node and attaches them
+  // to the relevant nodes in the AST
+
+  function AttachCommentTreeVisitorImpl() {
+    ParseTreeVisitor.call(this);
+  }
+  AttachCommentTreeVisitorImpl.prototype = Object.create(ParseTreeVisitor.prototype);
+  AttachCommentTreeVisitorImpl.prototype.constructor = AttachCommentTreeVisitorImpl;
+
+
+  AttachCommentTreeVisitorImpl.prototype.visit = function(tree, comments) {
+    this.comments = comments;
+    this.index = 0;
+    this.currentComment = this.comments[this.index];
+
+    if (this.currentComment) log.silly('comment: ' +
+        this.currentComment.range.start.line + ' - ' +
+        this.currentComment.range.end.line);
+
+    ParseTreeVisitor.prototype.visit.call(this, tree);
+  };
+
+
+  AttachCommentTreeVisitorImpl.prototype.visitAny = function(tree) {
+    if (tree && tree.location && tree.location.start && this.currentComment) {
+      if (this.currentComment.range.end.offset < tree.location.start.offset) {
+        log.silly('tree: ' + tree.constructor.name + ' - ' + tree.location.start.line);
+        tree.commentBefore = this.currentComment;
+        this.currentComment.treeAfter = tree;
+        this.index++;
+        this.currentComment = this.comments[this.index];
+        if (this.currentComment) log.silly('comment: ' + this.currentComment.range.start.line + ' - ' + this.currentComment.range.end.line);
+      }
+    }
+    return ParseTreeVisitor.prototype.visitAny.call(this, tree);
+  };
+
+  return AttachCommentTreeVisitorImpl;
+};

--- a/docs/traceur-package/services/ExportTreeVisitor.js
+++ b/docs/traceur-package/services/ExportTreeVisitor.js
@@ -1,0 +1,113 @@
+module.exports = function ExportTreeVisitor(ParseTreeVisitor, log) {
+
+  function ExportTreeVisitorImpl() {
+    ParseTreeVisitor.call(this);
+  }
+  ExportTreeVisitorImpl.prototype = Object.create(ParseTreeVisitor.prototype);
+
+  ExportTreeVisitorImpl.prototype.visitExportDeclaration = function(tree) {
+    // We are entering an export declaration - create an object to track it
+    this.currentExport = {
+      comment: tree.commentBefore,
+      location: tree.location
+    };
+    log.silly('enter', tree.type, tree.commentBefore ? 'has comment' : '');
+    ParseTreeVisitor.prototype.visitExportDeclaration.call(this, tree);
+    log.silly('exit', this.currentExport);
+
+    // We are exiting the export declaration - store the export object
+    this.exports.push(this.currentExport);
+    this.currentExport = null;
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitVariableStatement = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+      this.currentExport.name = "VARIABLE_STATEMENT";
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitVariableDeclaration = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+      this.currentExport.name = tree.lvalue;
+      this.currentExport.variableDeclaration = tree;
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitFunctionDeclaration = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+      this.currentExport.name = tree.name.identifierToken.value;
+      this.currentExport.functionKind = tree.functionKind;
+      this.currentExport.parameters = tree.parameterList.parameters;
+      this.currentExport.typeAnnotation = tree.typeAnnotation;
+      this.currentExport.annotations = tree.annotations;
+      this.currentExport.docType = 'function';
+
+      log.silly(tree.type, tree.commentBefore ? 'has comment' : '');
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitClassDeclaration = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+      this.currentExport.name = tree.name.identifierToken.value;
+      this.currentExport.superClass = tree.superClass;
+      this.currentExport.annotations = tree.annotations;
+      this.currentExport.elements = tree.elements;
+      this.currentExport.docType = 'class';
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitAsyncFunctionDeclaration = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitExportDefault = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+      this.currentExport.name = 'DEFAULT';
+      this.currentExport.defaultExport = tree;
+      // Default exports are either classes, functions or expressions
+      // So we let the super class continue down...
+      ParseTreeVisitor.prototype.visitExportDefault.call(this, tree);
+    }
+  };
+
+
+  ExportTreeVisitorImpl.prototype.visitNamedExport = function(tree) {
+    if ( this.currentExport ) {
+      this.updateExport(tree);
+
+      this.currentExport.namedExport = tree;
+      this.currentExport.name = 'NAMED_EXPORT';
+      // TODO: work out this bit!!
+      // We need to cope with any export specifiers in the named export
+    }
+  };
+
+
+  // TODO - if the export is an expression, find the thing that is being
+  // exported and use it and its comments for docs
+
+  ExportTreeVisitorImpl.prototype.updateExport = function(tree) {
+    this.currentExport.comment = this.currentExport.comment || tree.commentBefore;
+    this.currentExport.docType = tree.type;
+  };
+
+  ExportTreeVisitorImpl.prototype.visit = function(tree) {
+    this.exports = [];
+    ParseTreeVisitor.prototype.visit.call(this, tree);
+  };
+
+  return ExportTreeVisitorImpl;
+};

--- a/docs/traceur-package/services/atParser.js
+++ b/docs/traceur-package/services/atParser.js
@@ -1,0 +1,88 @@
+/**
+ * Wrapper around traceur that can parse the contents of a file
+ */
+module.exports = function atParser(AttachCommentTreeVisitor, SourceFile, Parser, traceurOptions, log) {
+
+  var service = {
+    /**
+     * The options to pass to traceur
+     */
+    traceurOptions: {
+      annotations: true,     // parse annotations
+      types: true,           // parse types
+      memberVariables: true, // parse class fields
+      commentCallback: true  // handle comments
+    },
+
+    /**
+     * Parse a module AST from the contents of a file.
+     * @param {Object} fileInfo information about the file to parse
+     * @return { { moduleTree: Object, comments: Array } } An object containing the parsed module
+     *             AST and an array of all the comments found in the file
+     */
+    parseModule: parseModule
+  };
+
+  return service;
+
+
+  // Parse the contents of the file using traceur
+  function parseModule(fileInfo) {
+
+    var moduleName = file2modulename(fileInfo.relativePath);
+    var sourceFile = new SourceFile(moduleName, fileInfo.content);
+    var comments = [];
+    var moduleTree;
+    var parser = new Parser(sourceFile);
+
+    // Configure the parser
+    parser.handleComment = function(range) {
+      comments.push({ range: range });
+    };
+    traceurOptions.setFromObject(service.traceurOptions);
+
+    try {
+      // Parse the file as a module, attaching the comments
+      moduleTree = parser.parseModule();
+      attachComments(moduleTree, comments);
+    } catch(ex) {
+      // HACK: sometime traceur crashes for various reasons including
+      // Not Yet Implemented (NYI)!
+      log.error(ex.stack);
+      moduleTree = {};
+    }
+    log.debug(moduleName);
+    moduleTree.moduleName = moduleName;
+
+    // We return the module AST but also a collection of all the comments
+    // since it can be helpful to iterate through them without having to
+    // traverse the AST again
+    return {
+      moduleTree: moduleTree,
+      comments: comments
+    };
+  }
+
+  // attach the comments to their nearest code tree
+  function attachComments(tree, comments) {
+
+    var visitor = new AttachCommentTreeVisitor();
+    // Visit every node of the tree using our custom method
+    visitor.visit(tree, comments);
+  }
+};
+
+
+function file2modulename(filePath) {
+  return filePath.replace(/\\/g, '/')
+    // module name should be relative to `modules` and `tools` folder
+    .replace(/.*\/modules\//, '')
+    .replace(/.*\/tools\//, '')
+    // module name should not include `src`, `test`, `lib`
+    .replace(/\/src\//, '/')
+    .replace(/\/web\//, '/')
+    .replace(/\/perf_tmp\//, '/')
+    .replace(/\/lib\//, '/')
+    // module name should not have a suffix
+    .replace(/\.\w*$/, '');
+}

--- a/docs/traceur-package/services/atParser.spec.js
+++ b/docs/traceur-package/services/atParser.spec.js
@@ -1,0 +1,80 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+
+describe('atParser service', function() {
+
+  var dgeni, injector, parser;
+
+  var fileContent =
+    'import {CONST} from "facade/lang";\n' +
+    '\n' +
+    '/**\n' +
+     '* A parameter annotation that creates a synchronous eager dependency.\n' +
+     '*\n' +
+     '*    class AComponent {\n' +
+     '*      constructor(@Inject("aServiceToken") aService) {}\n' +
+     '*    }\n' +
+     '*\n' +
+     '*/\n' +
+    'export class Inject {\n' +
+      'token;\n' +
+      '@CONST()\n' +
+      'constructor(token) {\n' +
+        'this.token = token;\n' +
+      '}\n' +
+    '}';
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    parser = injector.get('atParser');
+  });
+
+  it('should extract the comments from the file', function() {
+    var result = parser.parseModule({
+      content: fileContent,
+      relativePath: 'di/src/annotations.js'
+    });
+
+    expect(result.comments[0].range.toString()).toEqual(
+      '/**\n' +
+       '* A parameter annotation that creates a synchronous eager dependency.\n' +
+       '*\n' +
+       '*    class AComponent {\n' +
+       '*      constructor(@Inject("aServiceToken") aService) {}\n' +
+       '*    }\n' +
+       '*\n' +
+       '*/'
+    );
+  });
+
+  it('should extract a module AST from the file', function() {
+    var result = parser.parseModule({
+      content: fileContent,
+      relativePath: 'di/src/annotations.js'
+    });
+
+    expect(result.moduleTree.moduleName).toEqual('di/annotations');
+    expect(result.moduleTree.scriptItemList[0].type).toEqual('IMPORT_DECLARATION');
+
+    expect(result.moduleTree.scriptItemList[1].type).toEqual('EXPORT_DECLARATION');
+  });
+
+  it('should attach comments to their following AST', function() {
+    var result = parser.parseModule({
+      content: fileContent,
+      relativePath: 'di/src/annotations.js'
+    });
+
+    expect(result.moduleTree.scriptItemList[1].commentBefore.range.toString()).toEqual(
+      '/**\n' +
+       '* A parameter annotation that creates a synchronous eager dependency.\n' +
+       '*\n' +
+       '*    class AComponent {\n' +
+       '*      constructor(@Inject("aServiceToken") aService) {}\n' +
+       '*    }\n' +
+       '*\n' +
+       '*/'
+    );
+  });
+});

--- a/docs/traceur-package/services/getJSDocComment.js
+++ b/docs/traceur-package/services/getJSDocComment.js
@@ -1,0 +1,28 @@
+var LEADING_STAR = /^[^\S\r\n]*\*[^\S\n\r]?/gm;
+
+/**
+ * Extact comment info from a comment object
+ * @param {Object} comment object to process
+ * @return { {startingLine, endingLine, content, codeTree}= } a comment info object
+ *                          or undefined if the comment is not a jsdoc style comment
+ */
+module.exports = function getJSDocComment() {
+  return function(comment) {
+
+    var commentInfo;
+
+    // we need to check for `/**` at the start of the comment to find all the jsdoc style comments
+    comment.range.toString().replace(/^\/\*\*([\w\W]*)\*\/$/g, function(match, commentBody) {
+      commentBody = commentBody.replace(LEADING_STAR, '').trim();
+
+      commentInfo = {
+        startingLine: comment.range.start.line,
+        endingLine: comment.range.end.line,
+        content: commentBody,
+        codeTree: comment.treeAfter
+      };
+    });
+
+    return commentInfo;
+  };
+};

--- a/docs/traceur-package/services/getJSDocComment.spec.js
+++ b/docs/traceur-package/services/getJSDocComment.spec.js
@@ -1,0 +1,67 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+
+describe('getJSDocComment service', function() {
+
+  var dgeni, injector, getJSDocComment;
+
+  function createComment(commentString, start, end, codeTree) {
+    return {
+      range: {
+        toString: function() { return commentString; },
+        start: { line: start },
+        end: { line: end },
+      },
+      treeAfter: codeTree
+    };
+  }
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    getJSDocComment = injector.get('getJSDocComment');
+  });
+
+  it('should only return an object if the comment starts with /** and ends with */', function() {
+    var result = getJSDocComment(createComment('/** this is a jsdoc comment */'));
+    expect(result).toBeDefined();
+
+    result = getJSDocComment(createComment('/* this is a normal comment */'));
+    expect(result).toBeUndefined();
+
+    result = getJSDocComment(createComment('this is not a valid comment */'));
+    expect(result).toBeUndefined();
+
+    result = getJSDocComment(createComment('nor is this'));
+    expect(result).toBeUndefined();
+
+    result = getJSDocComment(createComment('/* or even this'));
+    expect(result).toBeUndefined();
+
+    result = getJSDocComment(createComment('/** and this'));
+    expect(result).toBeUndefined();
+  });
+
+
+  it('should return a result that contains info about the comment', function() {
+    var codeTree = {};
+    var result = getJSDocComment(createComment('/** this is a comment */', 10, 20, codeTree));
+    expect(result.startingLine).toEqual(10);
+    expect(result.endingLine).toEqual(20);
+    expect(result.codeTree).toBe(codeTree);
+  });
+
+  it('should strip off leading stars from each line', function() {
+    var result = getJSDocComment(createComment(
+      '/** this is a jsdoc comment */\n' +
+      ' *\n' +
+      ' * some content\n' +
+      ' */'
+    ));
+    expect(result.content).toEqual(
+      'this is a jsdoc comment */\n' +
+      '\n' +
+      'some content'
+    );
+  });
+});

--- a/docs/traceur-package/services/traceur.js
+++ b/docs/traceur-package/services/traceur.js
@@ -1,0 +1,19 @@
+var traceur = require('traceur/src/node/traceur.js');
+
+module.exports = {
+
+  traceurOptions: function traceurOptions() {
+    return traceur.options;
+  },
+
+  // We have to jump through some syntactic hoops to get classes out of
+  // Traceur for use in ES5 node apps
+  getClass: function(id, path) {
+    path = System.map.traceur + (path || ('/src/syntax/' + id));
+    var factory = function() {
+      return System.get(path)[id];
+    };
+    factory.name = id;
+    return factory;
+  }
+};

--- a/docs/traceur-package/templates/class.template.html
+++ b/docs/traceur-package/templates/class.template.html
@@ -1,0 +1,14 @@
+{% extends 'layout/base.template.html' %}
+
+{% block body %}
+<h1>{$ doc.name $} <span class="type">class</span></h1>
+<p class="module">exported from {$ doc.moduleDoc | relativeLink(doc) $}</p>
+<p>{$ doc.description | marked $}</p>
+
+<h2>Members</h2>
+{% for member in doc.members %}
+  <h3>{$ member.name $}</h3>
+  <p>{$ member.description | marked $}</p>
+{% endfor %}
+
+{% endblock %}

--- a/docs/traceur-package/templates/common.template.html
+++ b/docs/traceur-package/templates/common.template.html
@@ -1,0 +1,9 @@
+{% extends 'layout/base.template.html' %}
+
+{% block body %}
+<h1>{$ doc.id $}</h1>
+<h2>({$ doc.docType $})</h2>
+<div>
+{$ doc.description | marked $}
+</div>
+{% endblock %}

--- a/docs/traceur-package/templates/data-module.template.js
+++ b/docs/traceur-package/templates/data-module.template.js
@@ -1,0 +1,3 @@
+angular.module('{$ doc.moduleName $}', [])
+
+.value('{$ doc.serviceName $}', {$ doc.value | json $});

--- a/docs/traceur-package/templates/layout/base.template.html
+++ b/docs/traceur-package/templates/layout/base.template.html
@@ -1,0 +1,1 @@
+{% block body %}{% endblock %}

--- a/docs/traceur-package/templates/module.template.html
+++ b/docs/traceur-package/templates/module.template.html
@@ -1,0 +1,16 @@
+{% extends 'layout/base.template.html' %}
+
+{% block body %}
+<h1 class="id">{$ doc.id $} <span class="type">module</span></h1>
+
+<p>{$ doc.description | marked $}</p>
+
+{% if doc.exports.length %}
+<h2>Exports</h2>
+<ul>
+{%- for exportDoc in doc.exports %}
+  <li><a href="/{$ exportDoc.path $}">{$ exportDoc.name $} {$ exportDoc.docType $}</a></li>
+{%- endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,4 +72,12 @@ gulp.task('serve', function() {
 });
 
 gulp.task('docs', ['dgeni', 'static']);
+gulp.task('docs/serve', ['docs'], function() {
+  connect.server({
+    host: SERVER_CONFIG.host,
+    root: [__dirname + '/dist/docs'],
+    port: SERVER_CONFIG.port,
+    livereload: false
+  });
+});
 gulp.task('default', ['build', 'docs', 'serve', 'watch']);


### PR DESCRIPTION
This moves us forward a bit... Most of the Dgeni services and processors were taken from the Angular 2 doc gen - so this should be OK for migrating router into Angular 2.