### PR TITLE
fix(1.x/componentLoaderProvider): make provider methods chainable

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -279,9 +279,11 @@ function componentLoaderProvider() {
     },
     setCtrlNameMapping: function(newFn) {
       componentToCtrl = newFn;
+      return this;
     },
     setTemplateMapping: function(newFn) {
       componentToTemplate = newFn;
+      return this;
     }
   };
 }


### PR DESCRIPTION
This commit allows us to chain `componentLoaderProvider` methods like this:

```js
app.config(function (componentLoaderProvider) {
  componentLoaderProvider
    .setCtrlNameMapping(function (name) {
      // ...
    })
    .setTemplateMapping(function (name) {
      // ...
    });
});
```