### PR TITLE
fix(router-directive): handle route changes before template loading

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -89,6 +89,11 @@ function routerComponentDirective($animate, $controller, $compile, $rootScope, $
       $templateRequest(componentTemplateUrl).
           then(function(templateHtml) {
 
+            // If the route changed before we retrieved the template, then there is nothing else to do.
+            // TODO at the moment, this is a bad solution and hides the fact that we are compiling the same
+            //   directive twice.
+            if (!elt[0].parentNode) return;
+
             myOwnRouterComponentCtrl.template = templateHtml;
 
             var clone = $transclude(childScope, function(clone) {


### PR DESCRIPTION
When a template takes a long time to load and in between the route changes, then the template should not be transcluded.

This PR is hiding a real issue with a test, as it looks like inner routes-components are compiled twice