### PR TITLE
docs(configuration): fixes directive name

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -23,8 +23,8 @@ router.config([
 ```
 
 ```html
-<div router-component="master"></div>
-<div router-component="detail"></div>
+<div router-view-port="master"></div>
+<div router-view-port="detail"></div>
 ```
 
 ## redirectTo


### PR DESCRIPTION
`router-component` has been removed. `router-view-port` is the new
way to go.