### PR TITLE
chore(build): adds gulp-ng-annotate to build process

### DIFF
--- a/dist/router.es5.js
+++ b/dist/router.es5.js
@@ -148,6 +148,7 @@ function routerViewPortDirective($animate, $compile, $controller, $templateReque
     }, viewPortName);
   }
 }
+routerViewPortDirective.$inject = ["$animate", "$compile", "$controller", "$templateRequest", "$rootScope", "$location", "$componentLoader", "$router"];
 
 function routerViewPortFillContentDirective($compile) {
   return {
@@ -162,6 +163,7 @@ function routerViewPortFillContentDirective($compile) {
     }
   };
 }
+routerViewPortFillContentDirective.$inject = ["$compile"];
 
 function makeComponentString(name) {
   return [
@@ -247,6 +249,7 @@ function routerLinkDirective($router, $location, $parse) {
     }
   }
 }
+routerLinkDirective.$inject = ["$router", "$location", "$parse"];
 
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var connect = require('gulp-connect');
 var concat = require('gulp-concat');
 var merge = require('merge-stream');
 var rename = require('gulp-rename');
+var ngAnnotate = require('gulp-ng-annotate');
 
 var modulate = require('./scripts/angular-modulate');
 
@@ -37,6 +38,7 @@ gulp.task('angularify', ['transpile'], function() {
 
   return merge(directive, generated)
       .pipe(concat('router.es5.js'))
+      .pipe(ngAnnotate())
       .pipe(gulp.dest(BUILD_DIR));
 });
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp": "^3.8.9",
     "gulp-concat": "^2.4.2",
     "gulp-connect": "^2.0.6",
+    "gulp-ng-annotate": "^0.5.2",
     "gulp-rename": "^1.2.0",
     "gulp-traceur": "^0.13.0",
     "highlight.js": "^8.4.0",


### PR DESCRIPTION
Ensures that generated distribution source files use safe
dependency injection annotation syntax.

Closes #124