### PR TITLE
fix(docs): fix critical typo in configuration.md

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -17,7 +17,7 @@ You can configure multiple viewports on the same path like this:
 ```js
 $router.config([
   { path: '/user',
-    components: {
+    component: {
       master: 'userList',
       detail: 'user'
   } }


### PR DESCRIPTION
This PR contains a critical fix for the example in `configuration.md` when using sibling viewports.

The current example is broken and uses a `components` key in the mapping, which should be `component`.

This PR fixes the typo so the example becomes correct.