### PR TITLE
[feat] add ability to customize template by setting  property on controller con...

### DIFF
--- a/test/router-viewport.es5.spec.js
+++ b/test/router-viewport.es5.spec.js
@@ -26,10 +26,10 @@ describe('ngViewport', function () {
     });
 
     put('one', '<div>{{number}}</div>');
-    $controllerProvider.register('OneController', boringController('number', 'one'));
+    $controllerProvider.register('OneController', boringController('number', 'one', 'one'));
 
     put('two', '<div>{{number}}</div>');
-    $controllerProvider.register('TwoController', boringController('number', 'two'));
+    $controllerProvider.register('TwoController', boringController('number', 'two', 'two'));
   });
 
 
@@ -273,6 +273,38 @@ describe('ngViewport', function () {
     expect(elt.text()).toBe('hi');
   }));
 
+  it('should load a seperate template when a controller has a $template property', inject(function ($router) {
+    $templateCache.put('NonStandardDirectory/aNonStandardName.html', [200, 'hi', {}]);
+    $controllerProvider.register('TemplateController', TemplateController);
+    function TemplateController() {}
+    TemplateController.$template = {
+      url: 'NonStandardDirectory/aNonStandardName.html'
+    }
+    $router.config([
+      { path: '/t', component: 'template' }
+    ]);
+    compile('<div ng-viewport></div>');
+
+    $router.navigate('/t');
+    $rootScope.$digest();
+    expect(elt.text()).toBe('hi');
+  }));
+
+  it('should load a seperate template when a controller has a $template property', inject(function ($router) {
+    $controllerProvider.register('InlineTemplateController', InlineTemplateController);
+    function InlineTemplateController() {}
+    InlineTemplateController.$template = {
+      inline: 'hi'
+    }
+    $router.config([
+      { path: '/t', component: 'inlineTemplate' }
+    ]);
+    compile('<div ng-viewport></div>');
+
+    $router.navigate('/t');
+    $rootScope.$digest();
+    expect(elt.text()).toBe('hi');
+  }));
 
   it('should change location path', inject(function ($router, $location) {
 


### PR DESCRIPTION
...structor

After thinking about https://github.com/angular/router/issues/154 I decided a good first step would be to allow you to set a $template on a controller's constructor that will override the default template url returned by componentLoaderProvider. 

The syntax is essentially:

function MyController(...) {
...
}

MyController.$template = {
   url: 'anyDirectory/anyTemplateName.html'
}

This is in line with where #129 is headed and also matches nicely with the Angular 2 component syntax (it could become an annotation instead of a property just like the template annotation in Angular 2). It also allows you to add support for inline templates, so this works:

function MyController(...) {
...
}

MyController.$template = {
   inline: '<div>Hello!</div>'
}

Anyway, would love feedback if this seems like a good idea.

Also I'm not sure why it shows a bunch of additional changes from what looks like previous commits.