### PR TITLE
feat(helpers): add helpers module

### DIFF
--- a/src/helpers.ats
+++ b/src/helpers.ats
@@ -1,0 +1,67 @@
+/**
+ * Convert string to dash case
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export function dashCase(str: string) {
+  return str.replace(/([A-Z])/g, function ($1) {
+    return '-' + $1.toLowerCase();
+  });
+}
+
+/**
+ * Create deep copy of an object
+ *
+ * @param {Object} obj
+ * @returns {Object} deep copy
+ */
+export function copy(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+/**
+ * Check if no instruction was matched
+ *
+ * @param {Object} instruction
+ * @returns {boolean}
+ */
+export function notMatched(instruction) {
+  return instruction == null || instruction.length < 1;
+}
+
+/**
+ * Call function with each key/value pair of an object's properties
+ *
+ * @param {Object} obj
+ * @param {function} fn
+ * @returns undefined
+ */
+export function forEach(obj, fn) {
+  Object.keys(obj).forEach(key => fn(obj[key], key));
+}
+
+/**
+ * Creates a new array with the results of calling a provided function
+ * on every key/value pair in the object's properties
+ *
+ * @param {Object} obj
+ * @param {function} fn
+ * @returns {Array}
+ */
+export function mapObj(obj, fn) {
+  var result = [];
+  Object.keys(obj).forEach(key => result.push(fn(obj[key], key)));
+  return result;
+}
+
+/**
+ * Convert boolean to promise
+ *
+ * @param value
+ * @returns {Object} promise
+ */
+export function boolToPromise (value) {
+  return value ? Promise.resolve(value) : Promise.reject();
+}
+

--- a/test/helpers.spec.ats
+++ b/test/helpers.spec.ats
@@ -1,0 +1,134 @@
+import * as helpers from '../src/helpers';
+
+describe('helpers', () => {
+
+  describe('dashCase', () => {
+
+    it('should dasherize camelCase strings correctly', ()  => {
+      expect(helpers.dashCase('camelCaseString')).toEqual('camel-case-string');
+    });
+
+    it('should not change numbers', ()  => {
+      expect(helpers.dashCase('0123456789')).toEqual('0123456789');
+    });
+
+    it('should not change special characters', ()  => {
+      expect(helpers.dashCase('_-.')).toEqual('_-.');
+    });
+
+    it('should not change lowercase characters abcdefghijklmnopqrstuvwxyz', ()  => {
+      expect(helpers.dashCase('abcdefghijklmnopqrstuvwxyz')).toEqual('abcdefghijklmnopqrstuvwxyz');
+    });
+
+    it('should dasherize all uppercase characters ABCDEFGHIJKLMNOPQRSTUVWXYZ', ()  => {
+      expect(helpers.dashCase('ABCDEFGHIJKLMNOPQRSTUVWXYZ')).toEqual('-a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z');
+    });
+
+  });
+
+  describe('copy', () => {
+
+    it('should return a deep copy of an object', ()  => {
+      var obj = {
+        one: "1",
+        two: "2",
+        three: {
+          four: [5, 6]
+        }
+      };
+      expect(helpers.copy(obj)).toEqual(obj);
+      expect(helpers.copy(obj)).not.toBe(obj);
+    });
+
+  });
+
+  describe('notMatched', () => {
+
+    it('should return true if null value is passed', ()  => {
+      expect(helpers.notMatched()).toEqual(true);
+      expect(helpers.notMatched('')).toEqual(true);
+      expect(helpers.notMatched(undefined)).toEqual(true);
+    });
+
+    it('should return true if empty array is passed', ()  => {
+      expect(helpers.notMatched([])).toEqual(true);
+    });
+
+    it('should return false if non-empty array is passed', ()  => {
+      expect(helpers.notMatched([{}])).toEqual(false);
+    });
+
+    it('should return false if object is passed', ()  => {
+      expect(helpers.notMatched({})).toEqual(false);
+    });
+
+  });
+
+  describe('forEach', () => {
+
+    it('should call a function with each key/value pair of an object', ()  => {
+      var obj = {
+        one: "1",
+        two: "2",
+        three: {
+          four: [5, 6]
+        }
+      };
+      var fn = jasmine.createSpy('fn');
+      helpers.forEach(obj, fn);
+      expect(fn).toHaveBeenCalledWith("1", "one");
+      expect(fn).toHaveBeenCalledWith("2", "two");
+      expect(fn).toHaveBeenCalledWith({
+        four: [5, 6]
+      }, "three");
+    });
+
+  });
+
+  describe('mapObj', () => {
+
+    it('should apply a function to each key/value pair of an object', ()  => {
+      var obj = {
+        one: "1",
+        two: "2",
+        three: {
+          four: [5, 6]
+        }
+      };
+      var fn = function(value, key){
+        return {
+          value: value,
+          key: key
+        };
+      }
+      var output = helpers.mapObj(obj, fn);
+      expect(output).toEqual([
+        { value: obj['one'], key: 'one'},
+        { value: obj['two'], key: 'two'},
+        { value: obj['three'], key: 'three'}
+      ])
+    });
+
+  });
+
+  describe('boolToPromise', () => {
+
+    it('should return a resolved promise for truthy arguments', (done)  => {
+      helpers.boolToPromise(true).then(done, null);
+    });
+
+    it('should return a rejected promise for falsy arguments', (done)  => {
+      helpers.boolToPromise(false).then(null, done);
+    });
+
+    it('should pass the original argument to the success handler if truthy', (done)  => {
+      var obj = { one: '1' };
+      helpers.boolToPromise(obj).then(function(value){
+        expect(value).toBe(obj);
+        done();
+      }, null);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR contains a helpers module as proposed in #211.

### Goal

Centralize all helpers in a helpers module so they can be unit tested and reused in multiple places (e.g. in unit tests).

### Helpers module

A helpers module has been added as `src/helpers.ats`, exporting all helper functions so they can be individually imported:

```javascript
import {dashCase} from 'helpers';
```

or as a whole:

```javascript
import * as helpers from '../src/helpers';
helpers.dashCase('someString');
```

### Unit tests

Unit tests have been included to test the current behavior of the helpers.

![karma](https://cloud.githubusercontent.com/assets/1859381/6859267/41e1b3b6-d417-11e4-9cd1-01dbb8f53de5.png)

### Still left to do

@btford &mdash; I have not touched any of the existing router code so you will still have to import the helper functions in existing modules (e.g. `router.ats`) and refactor existing code yourself.

This is deliberate to:

- avoid code conflicts in case you already updated existing code by the time this PR is handled
- allow you to maybe rename helper functions before refactoring existing code (in case you want to name some functions differently now that they can be reused)

If this PR needs additional work, please don't hesitate to let me know.

Thanks!