### PR TITLE
docs(getting-started): fix router.es5.js module path

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -51,7 +51,7 @@ Let's start with the contents of `index.html`:
   <div ng-viewport></div>
 
   <script src="/node_modules/angular/angular.js"></script>
-  <script src="/dist/router.es5.js"></script>
+  <script src="/node_modules/angular-new-router/dist/router.es5.js"></script>
   <script src="/app/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION

In [getting started docs](https://angular.github.io/router/getting-started) router.es5.js module path is worng.
so this is PR to fix router.es5.js module path

```html
<script src="/node_modules/angular-new-router/dist/router.es5.js"></script>
```