### PR TITLE
docs($componentLoaderProvider): fix method name

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -517,7 +517,7 @@ function $componentLoaderProvider() {
     },
 
     /**
-     * @name $componentLoaderProvider#setCtrlNameMapping
+     * @name $componentLoaderProvider#setComponentFromCtrlMapping
      * @description takes a function for mapping component controller names to component names
      */
     setComponentFromCtrlMapping: function (newFn) {


### PR DESCRIPTION
Small error in the docs for the method named `setComponentFromCtrlMapping`.