### PR TITLE
docs(1.x): update directive names to ngLink and ngViewPort

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -109,7 +109,7 @@ function routerFactory($$rootRouter, $rootScope, $location, $$grammar, $controll
  * ## Use
  *
  * ```html
- * <div router-viewport="name"></div>
+ * <div ng-viewport="name"></div>
  * ```
  *
  * The value for the `ngViewport` attribute is optional.
@@ -256,7 +256,7 @@ var LINK_MICROSYNTAX_RE = /^(.+?)(?:\((.*)\))?$/;
  * Lets you link to different parts of the app, and automatically generates hrefs.
  *
  * ## Use
- * The directive uses a simple syntax: `router-link="componentName({ param: paramValue })"`
+ * The directive uses a simple syntax: `ng-link="componentName({ param: paramValue })"`
  *
  * ## Example
  *
@@ -270,7 +270,7 @@ var LINK_MICROSYNTAX_RE = /^(.+?)(?:\((.*)\))?$/;
  *
  * ```html
  * <div ng-controller="AppController as app">
- *   <a router-link="user({id: app.user.id})">{{app.user.name}}</a>
+ *   <a ng-link="user({id: app.user.id})">{{app.user.name}}</a>
  * </div>
  * ```
  */


### PR DESCRIPTION
The JS doc was still using the previous directive names.