### PR TITLE
fix(1.x): Store controller on new scope before transcluding.

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -181,13 +181,14 @@ function ngViewportDirective($animate, $injector, $q, $router) {
         myCtrl.$$router = instruction.router;
         myCtrl.$$template = instruction.template;
         var controllerAs = instruction.controllerAs || instruction.component;
+
+        var newController = instruction.controller;
+        newScope[controllerAs] = newController;
+
         var clone = $transclude(newScope, function(clone) {
           $animate.enter(clone, null, currentElement || $element);
           cleanupLastView();
         });
-
-        var newController = instruction.controller;
-        newScope[controllerAs] = newController;
 
         var result;
         if (currentController && currentController.deactivate) {

--- a/test/router-viewport.es5.spec.js
+++ b/test/router-viewport.es5.spec.js
@@ -650,6 +650,48 @@ describe('ngViewport', function () {
   });
 
 
+  it('should provide the controller initially to ng-init', function () {
+    var ctrl;
+    function Controller () {}
+    Controller.prototype.activate = function () {
+      ctrl = this;
+    };
+    registerComponent('init', '<p ng-init="init.foo = 5"></p>', Controller);
+
+    compile('<ng-viewport></ng-viewport>');
+
+    $router.config([
+      { path: '/', component: 'init' }
+    ]);
+
+    $router.navigate('/');
+    $rootScope.$digest();
+
+    expect(ctrl.foo).toBe(5);
+  });
+
+
+  it('should allow forms to be attached to the controller', function () {
+    var ctrl;
+    function Controller () {}
+    Controller.prototype.activate = function () {
+      ctrl = this;
+    };
+    registerComponent('form', '<form name="form.foo"></form>', Controller);
+
+    compile('<ng-viewport></ng-viewport>');
+
+    $router.config([
+      { path: '/', component: 'form' }
+    ]);
+
+    $router.navigate('/');
+    $rootScope.$digest();
+
+    expect(ctrl.foo).toBeDefined();
+    expect(ctrl.foo.$valid).toBe(true);
+  });
+
   function registerComponent(name, template, config) {
     if (!template) {
       template = '';


### PR DESCRIPTION
Prior to this, the transcluded template for an ng-viewport was compiled before storing the controller to the new scope.  This prevented storing things such as form controller instances on the controller (`<form name="ctrl.form">`).

Closes #270.

See the [plunker example](http://plnkr.co/edit/6SDLVjZG0gS0WsqJbgK1?p=preview) showing the bug, or the test cases added in this PR.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/router/273)

<!-- Reviewable:end -->
