### PR TITLE
fix: finish renaming "ports" field to "outlets"

### DIFF
--- a/src/pipeline.ats
+++ b/src/pipeline.ats
@@ -2,11 +2,11 @@ export class Pipeline {
   constructor() {
     this.steps = [
       instruction => instruction.router.makeDescendantRouters(instruction),
-      instruction => instruction.router.canDeactivatePorts(instruction),
-      instruction => instruction.router.traversePorts((port, name) => {
-        return boolToPromise(port.canActivate(instruction.outlets[name]));
+      instruction => instruction.router.canDeactivateOutlets(instruction),
+      instruction => instruction.router.traverseOutlets((outlet, name) => {
+        return boolToPromise(outlet.canActivate(instruction.outlets[name]));
       }),
-      instruction => instruction.router.activatePorts(instruction)
+      instruction => instruction.router.activateOutlets(instruction)
     ];
   }
   process(instruction) {

--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -400,7 +400,7 @@ function initLocalsStepFactory($componentMapper, $controllerIntrospector) {
 
 function runCanDeactivateHookStepFactory() {
   return function runCanDeactivateHook(instruction) {
-    return instruction.router.canDeactivatePorts(instruction);
+    return instruction.router.canDeactivateOutlets(instruction);
   };
 }
 
@@ -433,7 +433,7 @@ function loadTemplatesStepFactory($componentMapper, $templateRequest) {
 
 
 function activateStepValue(instruction) {
-  return instruction.router.activatePorts(instruction);
+  return instruction.router.activateOutlets(instruction);
 }
 
 
@@ -480,7 +480,7 @@ function pipelineProvider() {
 
 
 /**
- * @name $componentMapperFactory
+ * @name $componentMapper
  * @description
  *
  * This lets you configure conventions for what controllers are named and where to load templates from.

--- a/src/router.ats
+++ b/src/router.ats
@@ -41,7 +41,7 @@ class Router {
    * You probably don't need to use this unless you're writing a reusable component.
    */
   registerOutlet(view, name = 'default') {
-    this.ports[name] = view;
+    this.outlets[name] = view;
     return this.renavigate();
   }
 
@@ -142,14 +142,14 @@ class Router {
    * update outlets accordingly
    */
   canDeactivateOutlets(instruction) {
-    return this.traversePorts((outlet, name) => {
+    return this.traverseOutlets((outlet, name) => {
       return boolToPromise(outlet.canDeactivate(instruction.outlets[name]));
     });
   }
 
-  traversePorts(fn) {
+  traverseOutlets(fn) {
     return this.queryOutlets(fn)
-        .then(() => mapObjAsync(this.children, (child) => child.traversePorts(fn)));
+        .then(() => mapObjAsync(this.children, (child) => child.traverseOutlets(fn)));
   }
 
   queryOutlets(fn) {

--- a/test/router-viewport.es5.spec.js
+++ b/test/router-viewport.es5.spec.js
@@ -113,16 +113,16 @@ describe('ngOutlet', function () {
       { path: '/',         component:  {left: 'one', right: 'two'} },
       { path: '/switched', components: {left: 'two', right: 'one'} }
     ]);
-    compile('port 1: <div ng-outlet="left"></div> | ' +
-            'port 2: <div ng-outlet="right"></div>');
+    compile('outlet 1: <div ng-outlet="left"></div> | ' +
+            'outlet 2: <div ng-outlet="right"></div>');
 
     $router.navigate('/');
     $rootScope.$digest();
-    expect(elt.text()).toBe('port 1: one | port 2: two');
+    expect(elt.text()).toBe('outlet 1: one | outlet 2: two');
 
     $router.navigate('/switched');
     $rootScope.$digest();
-    expect(elt.text()).toBe('port 1: two | port 2: one');
+    expect(elt.text()).toBe('outlet 1: two | outlet 2: one');
   });
 
 
@@ -590,7 +590,7 @@ describe('ngOutlet', function () {
       { path: '/two', component: 'two' },
     ]);
 
-    compile('<a href="./two">link</a> | <div ng-viewport></div>');
+    compile('<a href="./two">link</a> | <div ng-outlet></div>');
     $rootScope.$digest();
     expect(elt.text()).toBe('link | one');
     elt.find('a').triggerHandler({ type: 'click', which: 3 });


### PR DESCRIPTION
Commit ce006080a3143397fe87e14759c0c04eb513d865 missed a few instances of "port", this PR finishes the job.

Also included is a tiny fix for dgeni not working due to incorrect `@name` annotation for `$componentMapper`.