### PR TITLE
fix($controllerIntrospectorProvider): fix instantiating of controllers that use the array DI notation

### DIFF
--- a/src/router-directive.es5.js
+++ b/src/router-directive.es5.js
@@ -46,19 +46,22 @@ function controllerProviderDecorator($controllerProvider, $controllerIntrospecto
  */
 function $controllerIntrospectorProvider() {
   var controllers = [];
-  var controllersByName = {};
+  var constructorsByName = {};
   var onControllerRegistered = null;
+
+  function getController(constructor) {
+    return angular.isArray(constructor) ? constructor[constructor.length - 1] : constructor;
+  }
+
   return {
     register: function (name, constructor) {
-      if (angular.isArray(constructor)) {
-        constructor = constructor[constructor.length - 1];
-      }
-      controllersByName[name] = constructor;
-      if (constructor.$routeConfig) {
+      var controller = getController(constructor);
+      constructorsByName[name] = constructor;
+      if (controller.$routeConfig) {
         if (onControllerRegistered) {
-          onControllerRegistered(name, constructor.$routeConfig);
+          onControllerRegistered(name, controller.$routeConfig);
         } else {
-          controllers.push({name: name, config: constructor.$routeConfig});
+          controllers.push({name: name, config: controller.$routeConfig});
         }
       }
     },
@@ -75,7 +78,7 @@ function $controllerIntrospectorProvider() {
       };
 
       fn.getTypeByName = function (name) {
-        return controllersByName[name];
+        return constructorsByName[name];
       };
 
       return fn;


### PR DESCRIPTION
Not sure about the best way to fix it, but here's one attempt.

This addresses the missing DI information when instantiating a controller that uses the array notation for DI in [this line](https://github.com/angular/router/blob/master/src/router-directive.es5.js#L389).