### PR TITLE
docs: change highlight annotations for Angular 2 to 'ts' and some typos

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -37,7 +37,7 @@ MyController.$routeConfig = [
 
 
 <!-- Angular 2 + TypeScript -->
-```js
+```ts
 @Component({})
 @View({
   template:
@@ -106,7 +106,7 @@ function MyController() {}
 ```
 <!-- End Angular 1 -->
 <!-- Angular 2 -->
-```js
+```ts
 @Component({})
 @View({
   directives: [RouterOutlet]
@@ -134,7 +134,7 @@ MyController.$routeConfig = [
 ```
 <!-- End Angular 1 -->
 <!-- Angular 2 -->
-```js
+```ts
 @Component({})
 @View({
   directives: [RouterOutlet]

--- a/src/router.ats
+++ b/src/router.ats
@@ -48,7 +48,7 @@ class Router {
 
   /**
    * @description
-   * Update the routing configuation and trigger a navigation.
+   * Update the routing configuration and trigger a navigation.
    *
    * ```js
    * router.config({ path: '/', component: '/user' });
@@ -64,7 +64,7 @@ class Router {
 
   /**
    * @description Navigate to a URL.
-   * Returns the cannonical URL for the route navigated to.
+   * Returns the canonical URL for the route navigated to.
    */
   navigate(url) {
     if (this.navigating) {
@@ -164,7 +164,7 @@ class Router {
 
 
   /**
-   * @description Navigates to either the last URL successfully naviagted to,
+   * @description Navigates to either the last URL successfully navigated to,
    * or the last URL requested if the router has yet to successfully navigate.
    * You shouldn't need to use this API very often.
    */


### PR DESCRIPTION
7c82fc4f9e02d7ed8d1c81a972e1fdabb3c01a76 broke the markdown processor as it was trying to use eshighlight for Typescript code (Angular 2).

Also fixed a few typos in router.ats comments

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/router/295)
<!-- Reviewable:end -->
