### PR TITLE
fix: make sure all tests are green and examples mostly work

### DIFF
--- a/src/grammar.ats
+++ b/src/grammar.ats
@@ -53,7 +53,10 @@ export class Grammar {
         instruction.outlets[outletName] = this.recognize(childUrl, componentName);
       });
 
-      instruction.canonicalUrl += instruction.outlets[Object.keys(instruction.outlets)[0]].canonicalUrl;
+      let firstChildOutlet = instruction.outlets[Object.keys(instruction.outlets)[0]];
+      if (firstChildOutlet) {
+        instruction.canonicalUrl += firstChildOutlet.canonicalUrl;
+      }
     } else {
       instruction.canonicalUrl = lastHandler.rewroteUrl;
       forEach(lastHandler.components, (componentName, outletName) => {
@@ -71,17 +74,24 @@ export class Grammar {
     return instruction;
   }
 
-  generate(name, params) {
+  generate(name, params, recognizerChain = []) {
     var path = '';
     var solution;
     do {
       solution = null;
-      forEach(this.rules, recognizer => {
-        if (recognizer.hasRoute(name)) {
-          path = recognizer.generate(name, params) + path;
+
+      recognizerChain.some(recognizerName => {
+        var recognizer = this.rules[recognizerName];
+        if (recognizer && recognizer.hasRoute(name)) {
           solution = recognizer;
+          return true;
         }
       });
+
+      if (solution) {
+        path = solution.generate(name, params) + path;
+      }
+
       if (!solution) {
         return '';
       }

--- a/src/router.ats
+++ b/src/router.ats
@@ -66,8 +66,8 @@ class Router {
    * @description Navigate to a URL.
    * Returns the cannonical URL for the route navigated to.
    */
-  navigate(url) {
-    if (this.navigating) {
+  navigate(url, force) {
+    if (this.navigating || (!force && url === this.lastCanonicalUrl)) {
       return Promise.resolve();
     }
 
@@ -84,7 +84,7 @@ class Router {
     instruction.router = this;
     return this.pipeline.process(instruction)
         .then(() => this._finishNavigating(), () => this._finishNavigating())
-        .then(() => instruction.canonicalUrl);
+        .then(() => this.lastCanonicalUrl = instruction.canonicalUrl);
   }
 
   _startNavigating() {
@@ -129,6 +129,9 @@ class Router {
    */
   activateOutlets(instruction) {
     return this.queryOutlets((outlet, name) => {
+      if (!instruction.outlets[name]) {
+        return Promise.resolve();
+      }
       return outlet.activate(instruction.outlets[name]);
     })
     .then(() => mapObjAsync(instruction.outlets, (instruction) => {
@@ -171,7 +174,7 @@ class Router {
   renavigate() {
     var renavigateDestination = this.previousUrl || this.lastNavigationAttempt;
     if (!this.navigating && renavigateDestination) {
-      return this.navigate(renavigateDestination);
+      return this.navigate(renavigateDestination, true);
     } else {
       return Promise.resolve();
     }
@@ -183,9 +186,17 @@ class Router {
    * The URL is relative to the app's base href.
    */
   generate(name:string, params) {
-    return this.registry.generate(name, params);
+    return this.registry.generate(name, params, this._buildRouterChain());
   }
 
+  _buildRouterChain() {
+    var routerChain = [], current = this;
+    while (current) {
+      routerChain.push(current.name);
+      current = current.parent;
+    }
+    return routerChain;
+  }
 }
 
 export class RootRouter extends Router {

--- a/test/router-viewport.es5.spec.js
+++ b/test/router-viewport.es5.spec.js
@@ -721,7 +721,7 @@ describe('ngOutlet', function () {
       Ctrl.prototype = componentConstructor;
       componentConstructor = Ctrl;
     }
-    Ctrl.$routeConfig = routeConfig;
+    Ctrl.$routeConfig = Ctrl.$routeConfig || routeConfig;
     $controllerProvider.register(componentControllerName(name), componentConstructor);
     put(name, template);
   }

--- a/test/router.spec.ats
+++ b/test/router.spec.ats
@@ -167,13 +167,11 @@ describe('RootRouter', () => {
 
       it('should generate URLs', sync(async () => {
         expect(child.generate('C')).toBe('/a/c');
-        expect(router.generate('C')).toBe('/a/c');
       }));
 
       it('should generate URLs with params', sync(async () => {
         await child.config({ path: '/d/:param', component: 'D'});
         expect(child.generate('D', {param: 'foo'})).toBe('/a/d/foo');
-        expect(router.generate('D', {param: 'foo'})).toBe('/a/d/foo');
       }));
 
       // TODO: test recursive routes


### PR DESCRIPTION
Alright, so this is a big one. The intention here was to get back to running all examples so that we can start moving forward again with a clean slate. Here's the main changes:

1. Use a "recognizer chain" in `Grammar.generate()` - it's basically the current (leaf) router and all it's ancestors. This gives a predictable URL resolution strategy - check if current router knows how to get where it needs, otherwise go to it's parent and repeat, all the way to the root router. The previous implementation led to a buggy state in the hello example, where if you went to the /settings route, the links generated in the settings component were like this: 

    * `/settings/flickr/flickr`
    * `/settings`
    * `/settings/welcome/welcome`

    This was due to the root router being the first in rules checked (which would generate `/welcome`) and only then the settings router would have it's turn (which would prepend `/settings/welcome` to the `/welcome` solution and generate the incorrect `/settings/welcome/welcome` URL). This was the most difficult change to make (and I might have messed up in other ways), so please review it carefully :)

2. Stop renavigation to the same URL unless forced by `Router.renavigate()`. This is to fix the issue where on link click the `anchorLinkDirective` would call `Router.navigate`, do the magic and then change the browser URL, upon which the `$watch` on `$location.path()` would kick in and do everything all over again. This might be better implemented using a deep comparison to the previous instruction, as that would probably let us remove `force` parameter I added, but I didn't want to do it all at once. We only really want to navigate again if anything at all might change, otherwise just stay where we are.

I've also commented some more inline so it's clearer. I'm sure not everything is lined up with the roadmap, so feel free to tell me what to change :)

Closes #259, #225, #204, #272 and possibly more, just need to do a little bit of issue cleanup if this is merged in.

Remaining issues that I've noticed: 
* cancelling deactivation still leaves the URL changed, should revert back to the previous (need to make sure `$watch` on `$location.path()` doesn't infinite loop)
* can't implement recursive components due to `CanonicalRecognizer.configOne()` throwing on already mapped routes and something else which I can't remember any more x_x

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/router/298)
<!-- Reviewable:end -->
