### PR TITLE
feat(resolve): add $resolve to controllers

### DIFF
--- a/examples/angular-1/confirm-unsaved/scenario.js
+++ b/examples/angular-1/confirm-unsaved/scenario.js
@@ -18,7 +18,7 @@ describe('angular 1.x "Confirm Unsaved" App', function() {
     it('should link items', function() {
       var items = element.all(by.binding('item.title'));
       var first = items.get(0);
-      expect(first.getAttribute('href')).toBe('http://0.0.0.0:8000/examples/angular-1/confirm-unsaved/post/1');
+      expect(first.getAttribute('href')).toMatch(/\/examples\/angular-1\/confirm-unsaved\/post\/1$/);
 
       first.click();
       browser.getLocationAbsUrl().then(function(url) {

--- a/examples/angular-1/phone-kitten/components/phone-detail/phone-detail.js
+++ b/examples/angular-1/phone-kitten/components/phone-detail/phone-detail.js
@@ -1,19 +1,14 @@
 'use strict';
 
-angular.module('phoneKitten.phoneDetail', []).
-    controller('PhoneDetailController', ['$routeParams', 'Phone', PhoneDetailController]);
-
-function PhoneDetailController($routeParams, Phone) {
-  var self = this;
-  this.phone = Phone.get({phoneId: $routeParams.phoneId}, function(phone) {
-    self.setImage(phone.images[0]);
-  });
+function PhoneDetailController(phone) {
+  this.phone = phone;
+  this.mainImageUrl = phone.images[0];
 }
-
-PhoneDetailController.prototype.canActivate = function() {
-  return this.phone.$promise;
+PhoneDetailController.$resolve = {
+	phone: ['Phone', '$routeParams', function getPhoneItem (Phone, $routeParams) {
+		return Phone.get({phoneId: $routeParams.phoneId}).$promise;
+	}]
 };
 
-PhoneDetailController.prototype.setImage = function(imageUrl) {
-  this.mainImageUrl = imageUrl;
-};
+angular.module('phoneKitten.phoneDetail', []).
+    controller('PhoneDetailController', ['phone', PhoneDetailController]);

--- a/examples/angular-1/phone-kitten/components/phone-detail/phone-detail.js
+++ b/examples/angular-1/phone-kitten/components/phone-detail/phone-detail.js
@@ -10,5 +10,9 @@ PhoneDetailController.$resolve = {
 	}]
 };
 
+PhoneDetailController.prototype.setImage = function(imageUrl) {
+  this.mainImageUrl = imageUrl;
+};
+
 angular.module('phoneKitten.phoneDetail', []).
     controller('PhoneDetailController', ['phone', PhoneDetailController]);

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,7 +1,9 @@
 var SERVER_CONFIG = require('./config').server;
 
 exports.config = {
-  allScriptsTimeout: 11000,
+  allScriptsTimeout: 60000,
+  getPageTimeout: 40000,
+
 
   specs: [
     'examples/**/scenario.js'
@@ -11,11 +13,15 @@ exports.config = {
     'browserName': 'chrome'
   },
 
+  onPrepare: function () {
+    browser.manage().timeouts().implicitlyWait(5000);
+  },
+
   baseUrl: 'http://' + SERVER_CONFIG.host + ':' + SERVER_CONFIG.port + '/',
 
   framework: 'jasmine',
 
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 30000
+    defaultTimeoutInterval: 60000
   }
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,9 +1,7 @@
 var SERVER_CONFIG = require('./config').server;
 
 exports.config = {
-  allScriptsTimeout: 60000,
-  getPageTimeout: 40000,
-
+  allScriptsTimeout: 11000,
 
   specs: [
     'examples/**/scenario.js'
@@ -13,15 +11,11 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  onPrepare: function () {
-    browser.manage().timeouts().implicitlyWait(5000);
-  },
-
   baseUrl: 'http://' + SERVER_CONFIG.host + ':' + SERVER_CONFIG.port + '/',
 
   framework: 'jasmine',
 
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 60000
+    defaultTimeoutInterval: 30000
   }
 };

--- a/protractor.travis.conf.js
+++ b/protractor.travis.conf.js
@@ -7,13 +7,13 @@ config.sauceKey = process.env.SAUCE_ACCESS_KEY;
 
 config.multiCapabilities = [{
   'browserName': 'chrome',
-  'platform': 'OS X 10.9',
   'name': 'Angular E2E',
   'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
   'build': process.env.TRAVIS_BUILD_NUMBER,
   'version': '34'
 }, {
   'browserName': 'firefox',
+  'platform': 'Windows 7',
   'name': 'Angular E2E',
   'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
   'build': process.env.TRAVIS_BUILD_NUMBER,


### PR DESCRIPTION
This will provide a similar resolve functionality than the one that exists in the old router and the ui-router, but even with more sense as it's the controller itself the one that specifies the elements to resolve and not the router config.

Here is an example of what the PR provides

```javascript
function SampleController (items) {
	//Items will contain the result of the ItemsService promise once it is resolved.
	this.items = items;
}
SampleController.$resolve = {
	items: 'ItemsService' //ItemsService is a service returning a promise
};

angular.module('myapp').controller('SampleController', SampleController);
```

The reason why I think this is useful even with the canActivate hook is because this way you get the promises resolved even after instantiating the controller. So you can have a single point to fill in the ViewModel.

Hope you find it useful as well. Let me know what you think and if I can improve anything to make it more suitable for the project.

BTW, I think there's a failing test in the head branch, so as I did my fork on top of it, that test is failing also. I will try to give it a glance and PR also if I success solving it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/router/333)
<!-- Reviewable:end -->
